### PR TITLE
Take build number from parent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "A simple way to deploy your application to a remote location.",
     "license": "proprietary",
     "require": {
-        "october/system": "^2.0.16",
+        "october/system": "^2.1.2",
         "composer/installers": "~1.0"
     }
 }

--- a/controllers/Servers.php
+++ b/controllers/Servers.php
@@ -341,11 +341,7 @@ class Servers extends SettingsController
         ];
 
         if (post('deploy_core')) {
-            $deployActions[] = [
-                'label' => 'Setting Build Number',
-                'action' => 'transmitArtisan',
-                'artisan' => 'october:util set build'
-            ];
+            $this->injectSetBuildStep($deployActions);
         }
 
         $deployActions[] = [
@@ -459,11 +455,7 @@ class Servers extends SettingsController
             'artisan' => 'october:migrate'
         ];
 
-        $deployActions[] = [
-            'label' => 'Setting Build Number',
-            'action' => 'transmitArtisan',
-            'artisan' => 'october:util set build'
-        ];
+        $this->injectSetBuildStep($deployActions);
 
         $deployActions[] = [
             'label' => 'Finishing Up',
@@ -474,6 +466,19 @@ class Servers extends SettingsController
         return $this->deployerWidget->executeSteps($serverId, $deployActions);
     }
 
+    /**
+     * injectSetBuildStep
+     */
+    protected function injectSetBuildStep(array &$deployActions): void
+    {
+        $build = \System\Models\Parameter::get('system::core.build', 0);
+
+        $deployActions[] = [
+            'label' => 'Setting Build Number',
+            'action' => 'transmitArtisan',
+            'artisan' => 'october:util set build --value='.$build
+        ];
+    }
 
     /**
      * manage_onLoadUpgradeLegacy upgrades a legacy version


### PR DESCRIPTION
This removes the need for the child server to scan for itself. Requires OC 2.1.2